### PR TITLE
fix(queries): filter active collections in get_collections_info_sync

### DIFF
--- a/src/app/services/sql_db/queries.py
+++ b/src/app/services/sql_db/queries.py
@@ -49,9 +49,13 @@ def get_collections_sync():
 
 
 def get_collections_info_sync():
-    stmt = select(
-        Corpus.source_name, Corpus.is_active, Category.title.label("category_name")
-    ).outerjoin(Category, Corpus.category_id == Category.id)
+    stmt = (
+        select(
+            Corpus.source_name, Corpus.is_active, Category.title.label("category_name")
+        )
+        .outerjoin(Category, Corpus.category_id == Category.id)
+        .where(Corpus.is_active)
+    )
 
     with session_maker() as session:
         results = session.execute(stmt).all()


### PR DESCRIPTION
This pull request updates the `get_collections_info_sync` function in `queries.py` to ensure that only active corpora are returned in the query results. The change also improves the readability of the query construction.

Query filtering and code readability:

* Modified the SQLAlchemy query in `get_collections_info_sync` to filter results by `Corpus.is_active`, so only active corpora are included, and reformatted the query for better readability.