### PR TITLE
Set LLM temperature in env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ AZURE_API_BASE=https://fake-openai.example.com
 AZURE_API_VERSION=0000-00-00-preview
 
 LLM_MODEL_NAME=fake-llm-model
+LLM_TEMPERATURE=0.7
 
 ##### POSTGRES #########
 # PG_HOST=fake-prod-postgres.example.com

--- a/k8s/welearn-api/values.yaml
+++ b/k8s/welearn-api/values.yaml
@@ -38,6 +38,7 @@ config:
     AZURE_API_BASE: "https://welearn-openai.openai.azure.com/openai/"
     AZURE_API_VERSION: "2024-08-01-preview"
     LLM_MODEL_NAME: gpt-oss-120b
+    LLM_TEMPERATURE: "0.2"
     MISTRAL_LLM_MODEL_NAME: mistral-small-latest
     QDRANT_HOST: "http://qdrant.qdrant"
     QDRANT_PORT: "6333"

--- a/k8s/welearn-api/values.yaml
+++ b/k8s/welearn-api/values.yaml
@@ -38,7 +38,7 @@ config:
     AZURE_API_BASE: "https://welearn-openai.openai.azure.com/openai/"
     AZURE_API_VERSION: "2024-08-01-preview"
     LLM_MODEL_NAME: gpt-oss-120b
-    LLM_TEMPERATURE: "0.2"
+    LLM_TEMPERATURE: 0.2
     MISTRAL_LLM_MODEL_NAME: mistral-small-latest
     QDRANT_HOST: "http://qdrant.qdrant"
     QDRANT_PORT: "6333"

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -47,6 +47,7 @@ class Settings(BaseSettings):
     AZURE_API_VERSION: str
 
     LLM_MODEL_NAME: str
+    LLM_TEMPERATURE: float
     ENV: str
 
     # PG

--- a/src/app/shared/infra/abst_chat.py
+++ b/src/app/shared/infra/abst_chat.py
@@ -405,6 +405,7 @@ class AbstractChat(ABC):
         settings = get_settings()
         agent_model = ChatMistralAI(
             model_name=settings.MISTRAL_LLM_MODEL_NAME,
+            temperature=settings.LLM_TEMPERATURE,
         )
 
         self.agent_executor = create_agent(

--- a/src/app/tutor/service/tutor.py
+++ b/src/app/tutor/service/tutor.py
@@ -51,6 +51,7 @@ async def init_chat_model(settings) -> None:
     if chat_model is None:
         chat_model = ChatMistralAI(
             model_name=settings.MISTRAL_LLM_MODEL_NAME,
+            temperature=settings.LLM_TEMPERATURE,
         )
 
 


### PR DESCRIPTION
This pull request introduces support for configuring the temperature parameter of the LLM (Large Language Model) via environment variables and configuration files. The temperature setting, which controls the randomness of the model's output, is now passed through the configuration and used when initializing the chat model. This enables more flexibility and control over LLM responses in different environments.

**Configuration and Environment Variable Updates:**

* Added `LLM_TEMPERATURE` to `.env.example` to document the new environment variable for local development and deployment.
* Updated `k8s/welearn-api/values.yaml` to include `LLM_TEMPERATURE` in the Kubernetes deployment configuration, allowing the temperature to be set per environment.

**Codebase and Application Logic:**

* Added `LLM_TEMPERATURE` as a `float` field in the application settings schema in `src/app/core/config.py`, making it accessible throughout the application.
* Updated the initialization of `ChatMistralAI` in both `src/app/shared/infra/abst_chat.py` and `src/app/tutor/service/tutor.py` to pass the `temperature` parameter from settings, ensuring the model uses the configured temperature. [[1]](diffhunk://#diff-4a5712c8dfbcada77c1b4384c75e851c48c3c468f007a085c88b0cb2215e427eR408) [[2]](diffhunk://#diff-6c3e84535658a9e103dd4dd2f977b3b5b340ff729835c9ccdb046e27ce2862a5R54)